### PR TITLE
API changed, fixed based on headers added

### DIFF
--- a/datosgobes/manager.py
+++ b/datosgobes/manager.py
@@ -6,6 +6,8 @@ class Manager:
     def __init__(self) -> None:
         self.url = "http://datos.gob.es/apidata" 
         self._search_result = None   
+        ## based on https://stackoverflow.com/questions/41946166/requests-get-returns-403-while-the-same-url-works-in-browser
+        self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36'}
 
     def _list_datasets(self, start_page=0, pages_limit=1):
         """Get the collection of datasets from the portal. The collection is huge, so be sure to limit the number of pages to download.
@@ -22,7 +24,7 @@ class Manager:
         i = start_page
         while start_url and i<pages_limit+start_page:
             # Download the page
-            response = requests.get(start_url)
+            response = requests.get(start_url, headers=self.headers)
             data = response.json()
 
             # Extract and normalize the datasets
@@ -54,7 +56,7 @@ class Manager:
         i = start_page
         while start_url and i<pages_limit+start_page:
             # Download the page
-            response = requests.get(start_url)
+            response = requests.get(start_url, headers=self.headers)
             data = response.json()
 
             # Extract and normalize the datasets

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="datosgobes",
     description="Python package to access Spanish Government Open Data from the datos.gob.es API",
-    version="0.1.0",
+    version="0.1.1",
     author="Juan Valero",
     author_email="olietvalero@gmail.com",
     url="https://github.com/jvaleroliet/datosgobes",


### PR DESCRIPTION
Hello,

I wanted to use your library to check some datos.gob.es datasets, but it failed with the requests error 403. I researched for a bit and I found out in here (https://stackoverflow.com/questions/41946166/requests-get-returns-403-while-the-same-url-works-in-browser) that the API could be requesting for a defined browser.

I applied the changes to the library so the browser is defined. Maybe it would be better to have a condition to do it or not. But for now it is working.

Hope you find this useful.

BTW: I'm spanish and the scopus of this library is a spanish API. Should this pull request be in Spanish also? Don't know, but for future interactions ;)