### PR TITLE
Minor change in the API? Next item doesn't exist on the dictionary

### DIFF
--- a/datosgobes/manager.py
+++ b/datosgobes/manager.py
@@ -34,7 +34,10 @@ class Manager:
             all_datasets += page_datasets
 
             # Obtain the URL for the next page
-            next_page_url = data["result"]["next"]
+            if "next" in data["result"].keys():
+                next_page_url = data["result"]["next"]
+            else:
+                next_page_url = None
             start_url = next_page_url if next_page_url else None
             if pages_limit != None:
                 i+=1

--- a/datosgobes/manager.py
+++ b/datosgobes/manager.py
@@ -6,6 +6,8 @@ class Manager:
     def __init__(self) -> None:
         self.url = "http://datos.gob.es/apidata" 
         self._search_result = None   
+        ## based on https://stackoverflow.com/questions/41946166/requests-get-returns-403-while-the-same-url-works-in-browser
+        self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36'}
 
     def _list_datasets(self, start_page=0, pages_limit=1):
         """Get the collection of datasets from the portal. The collection is huge, so be sure to limit the number of pages to download.
@@ -22,7 +24,7 @@ class Manager:
         i = start_page
         while start_url and i<pages_limit+start_page:
             # Download the page
-            response = requests.get(start_url)
+            response = requests.get(start_url, headers=self.headers)
             data = response.json()
 
             # Extract and normalize the datasets
@@ -54,7 +56,7 @@ class Manager:
         i = start_page
         while start_url and i<pages_limit+start_page:
             # Download the page
-            response = requests.get(start_url)
+            response = requests.get(start_url, headers=self.headers)
             data = response.json()
 
             # Extract and normalize the datasets

--- a/datosgobes/manager.py
+++ b/datosgobes/manager.py
@@ -3,11 +3,16 @@ import pandas as pd
 from .opendataset import OpenDataSet
 
 class Manager:
-    def __init__(self) -> None:
+    def __init__(self, headers=None) -> None:
         self.url = "http://datos.gob.es/apidata" 
         self._search_result = None   
         ## based on https://stackoverflow.com/questions/41946166/requests-get-returns-403-while-the-same-url-works-in-browser
-        self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36'}
+        if headers == True:
+            self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36'}
+        elif type(headers) == dict or headers is None:
+            self.headers = headers
+        else:
+            raise ValueError("headers param must be True, None, or a dictionary")
 
     def _list_datasets(self, start_page=0, pages_limit=1):
         """Get the collection of datasets from the portal. The collection is huge, so be sure to limit the number of pages to download.
@@ -69,7 +74,10 @@ class Manager:
             all_datasets += page_datasets
 
             # Obtain the URL for the next page
-            next_page_url = data["result"]["next"]
+            if "next" in data["result"].keys():
+                next_page_url = data["result"]["next"]
+            else:
+                next_page_url = None
             start_url = next_page_url if next_page_url else None
             if pages_limit != None:
                 i+=1
@@ -95,9 +103,11 @@ class Manager:
         return datasets
     
     def _create_dataset(self, dataset_meta: dict) -> OpenDataSet:
-        dataset = OpenDataSet(url=dataset_meta["_about"])
+        dataset = OpenDataSet(url=dataset_meta["_about"],
+                              headers=self.headers)
         return dataset
     
     def get_dataset(self, id: str) -> OpenDataSet:
-        dataset = OpenDataSet(url=f'{self.url}/catalog/dataset/{id}')
+        dataset = OpenDataSet(url=f'{self.url}/catalog/dataset/{id}',
+                              headers=self.headers)
         return dataset

--- a/datosgobes/opendataset.py
+++ b/datosgobes/opendataset.py
@@ -5,10 +5,17 @@ from .data_download import download_data
 
 
 class OpenDataSet:
-    def __init__(self, url:str):
+    def __init__(self, url:str, headers=None):
         self.url = url
         self.id = url.split('/')[-1]
         # self.metadata = {}
+        ## based on https://stackoverflow.com/questions/41946166/requests-get-returns-403-while-the-same-url-works-in-browser
+        if headers == True:
+            self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36'}
+        elif type(headers) == dict or headers is None:
+            self.headers = headers
+        else:
+            raise ValueError("headers param must be True, None, or a dictionary")
     
     def __repr__(self):
         return f"OpenDataSet('{self.id}')"
@@ -16,7 +23,8 @@ class OpenDataSet:
     @property    
     def metadata(self):
         # Fetch metadata from the API
-        response = requests.get(f"http://datos.gob.es/apidata/catalog/dataset/{self.id}")
+        response = requests.get(f"http://datos.gob.es/apidata/catalog/dataset/{self.id}",
+                                headers=self.headers)
         return response.json()["result"]["items"][0]
         
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="datosgobes",
     description="Python package to access Spanish Government Open Data from the datos.gob.es API",
-    version="0.1.0",
+    version="0.1.1",
     author="Juan Valero",
     author_email="olietvalero@gmail.com",
     url="https://github.com/jvaleroliet/datosgobes",


### PR DESCRIPTION
The _query_datasets method looks for a next item in the dictionary. However, in the case of searching for "fertilizantes" it didn't appeared. Hence, I added a condition to check if the "next" item exists prior to search it.